### PR TITLE
Rename Spylog to Shylog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changelog, this file
 
 ### Changed
-- Rename tha package name to Shylog
+- Rename the package name to Shylog
 - Pass the whole message object to `externalLogger`
+- Update spec to match new implementation
 
 ## [0.1.0] - 2019-02-22
 ### Added
-- Initial release, adds the base implemenatiaon of Spylog
+- Initial release, adds the base implementation of Spylog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2019-03-04
+### Added
+- Changelog, this file
+
+### Changed
+- Rename tha package name to Shylog
+- Pass the whole message object to `externalLogger`
+
+## [0.1.0] - 2019-02-22
+### Added
+- Initial release, adds the base implemenatiaon of Spylog

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Spylog
+# Shylog
 
 > Tiny client-side conditional logger

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "spylog",
-  "version": "0.1.0",
+  "name": "shylog",
+  "version": "0.1.1",
   "description": "Tiny client-side conditional logger",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": ["build/**/*"],
   "author": "Vadim Brodsky <vadim.brodsky@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/VadimBrodsky/spylog",
+  "homepage": "https://github.com/VadimBrodsky/shylog",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/VadimBrodsky/spylog.git"
+    "url": "git+https://github.com/VadimBrodsky/shylog.git"
   },
   "keywords": ["logger", "console", "tiny", "conditional", "debug", "browser", "client"],
   "bugs": {
-    "url": "https://github.com/VadimBrodsky/spylog/issues"
+    "url": "https://github.com/VadimBrodsky/shylog/issues"
   },
   "devDependencies": {
     "@types/jest": "^24.0.6",

--- a/src/__tests__/shylog.test.ts
+++ b/src/__tests__/shylog.test.ts
@@ -1,11 +1,11 @@
-import Spylog from '../lib';
+import Shylog from '../lib';
 
-describe('Spylog', () => {
+describe('Shylog', () => {
   describe('constructor', () => {
     it('should not log anything if emit set to false', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => jest.fn());
 
-      const logger = new Spylog({
+      const logger = new Shylog({
         emit: false,
         logger: console.log
       });
@@ -19,7 +19,7 @@ describe('Spylog', () => {
     it('should accept an external logger', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => jest.fn());
 
-      const logger = new Spylog({
+      const logger = new Shylog({
         emit: true,
         logger: console.log
       });
@@ -33,7 +33,7 @@ describe('Spylog', () => {
 
   describe('.error', () => {
     it('should store the error message', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
 
       expect(logger.error).toBeDefined();
       logger.error('Abort', { failed: true });
@@ -45,7 +45,7 @@ describe('Spylog', () => {
 
   describe('.warn', () => {
     it('should store the warn message', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
 
       expect(logger.warn).toBeDefined();
       logger.warn('That', 'was', 'a', 'close', 'call');
@@ -57,7 +57,7 @@ describe('Spylog', () => {
 
   describe('.info', () => {
     it('should store the info message', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
 
       expect(logger.info).toBeDefined();
       logger.info('Back to normal');
@@ -69,7 +69,7 @@ describe('Spylog', () => {
 
   describe('.log', () => {
     it('should store the log message', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
 
       expect(logger.log).toBeDefined();
       logger.log('Something happened');
@@ -81,7 +81,7 @@ describe('Spylog', () => {
 
   describe('.setLevel', () => {
     it('should return a custom log level function', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
       const panic = logger.setLevel('panic');
 
       panic('FIRE! FIRE! FIRE!');
@@ -91,7 +91,7 @@ describe('Spylog', () => {
 
   describe('.getLogs', () => {
     it('should return all logged items when has no parameters', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
 
       logger.log('Something happened');
       logger.error('Abort', { failed: true });
@@ -102,7 +102,7 @@ describe('Spylog', () => {
     });
 
     it('should return all logged  items for a specified level number', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
 
       logger.error('first error');
       logger.error('second error');
@@ -114,7 +114,7 @@ describe('Spylog', () => {
     });
 
     it('should return all logged items for a specified log function', () => {
-      const logger = new Spylog();
+      const logger = new Shylog();
 
       logger.warn('warn 1st');
       logger.warn('warn 2nd');

--- a/src/__tests__/shylog.test.ts
+++ b/src/__tests__/shylog.test.ts
@@ -27,7 +27,9 @@ describe('Shylog', () => {
       const logMessage = 'Can you see this?';
       logger.log(logMessage);
 
-      expect(consoleSpy).toHaveBeenCalledWith(logMessage);
+      expect(consoleSpy.mock.calls[0][0].msg).toEqual(logMessage);
+      expect(consoleSpy.mock.calls[0][0].msg).toEqual(logMessage);
+      expect(consoleSpy.mock.calls[0][0].time).toBeDefined();
     });
   });
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -18,7 +18,7 @@ interface LogFn {
   level: Log['level'];
 }
 
-class Spylog {
+class Shylog {
   private emit: boolean;
   private buffer: Log[];
   private externalLogger: (...args: unknown[]) => unknown;
@@ -62,4 +62,4 @@ class Spylog {
   }
 }
 
-export default Spylog;
+export default Shylog;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -51,8 +51,9 @@ class Shylog {
 
   public setLevel(level: Log['level'] | string): LogFn {
     const logFn: LogFn = (...args: unknown[]) => {
-      this.buffer.push({ level, time: Date.now(), msg: args.join(' ') });
-      this.emit && this.externalLogger(...args);
+      const message = { level, time: Date.now(), msg: args.join(' ') };
+      this.buffer.push(message);
+      this.emit && this.externalLogger(message);
     };
 
     logFn.level = level;


### PR DESCRIPTION
## [0.1.1] - 2019-03-04
### Added
- Changelog, this file

### Changed
- Rename the package name to Shylog
- Pass the whole message object to `externalLogger`
- Update spec to match new implementation